### PR TITLE
added zlib1g-dev dependency for spicy-build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -q update \
      make \
      g++ \
      libpcap0.8-dev \
+     zlib1g-dev \
      pipx \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I was following the guide: https://docs.zeek.org/projects/spicy/en/latest/getting-started.html#hello-world

When using the spicy-build command
```
spicy-build -o a.out hello.spicy
```

got an error:
```
root@a2beb9fef38a:/workspaces/zeek-playground# spicy-build -o a.out hello.spicy 
/usr/bin/ld: cannot find -lz: No such file or directory
collect2: error: ld returned 1 exit status
```

Had an issue not having zlib compression. 
Fix is adding the zlib1g-dev package to the Dockerfile.
